### PR TITLE
Jcailly/fix team image lcp

### DIFF
--- a/src/components/marketing/landing/visitor/featured/index.tsx
+++ b/src/components/marketing/landing/visitor/featured/index.tsx
@@ -56,9 +56,11 @@ const Featured: React.FC = () => {
           <Image
             src={"/static/images/onruntime-team.jpg"}
             alt={"Équipe onRuntime Studio"}
-            width={6000}
-            height={4000}
+            width={1024}
+            height={510}
             className="z-[-1] max-h-[510px] object-cover"
+            priority
+            sizes="100vw"
           />
 
           <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent flex flex-col justify-end items-center p-5 md:p-10 gap-5">


### PR DESCRIPTION
This modification improve home page's performance in mobile's lighthouse performance audit by fixing the image size. This avoid to lazy load the LCP and improve the LCP loading time 0.5s to 1s about.