### PR TITLE
:wheelchair: improve homepage accessibility by fixing name issue on contact button

### DIFF
--- a/src/components/marketing/navbar/index.tsx
+++ b/src/components/marketing/navbar/index.tsx
@@ -137,7 +137,7 @@ const Navbar: React.FC = () => {
 					<Navigation />
 
 					<div className="flex gap-2">
-						<Link href={Routes.contact}>
+						<Link href={Routes.contact} aria-label="Nous contacter" passHref>
 							<Button className="hidden md:inline-flex" variant="outline">
 								Nous contacter
 							</Button>


### PR DESCRIPTION
Fix the mobile's lighthouse accessibility audit "Links do not have a discernible name" by adding aria-label="Nous contacter" to the Link tag.
This minor modification improve the Lighthouse accessibility score of 4%.