### PR TITLE
:mag: update metadata on agency page

### DIFF
--- a/src/app/agency/page.tsx
+++ b/src/app/agency/page.tsx
@@ -12,8 +12,7 @@ import { OrganizationSchema } from '@/components/json-ld/organization-schema';
 
 export const metadata = constructMetadata({
   title: "Expertise digitale locale dans les grandes villes françaises",
-  description: "Nous aidons les entreprises locales en France via notre expertise des marchés numériques régionaux ; des solutions sur-mesure pour chaque territoire.",
-  canonical: "https://onruntime.com/agency",
+  description: "Nous aidons les entreprises locales en France via notre expertise des marchés numériques régionaux ; des solutions sur-mesure pour chaque territoire."
 });
 
 export default function AgencyLandingPage() {


### PR DESCRIPTION
This modification update metadata for agency page. Add a canonical link and refactor title and description to match 60 and 155 characters respectiv limit and avoid truncated informations.