### PR TITLE
🔍 add canonical link to homepage

### DIFF
--- a/src/app/(landing)/page.ts
+++ b/src/app/(landing)/page.ts
@@ -4,6 +4,7 @@ import VisitorLanding from "@/screens/marketing/landing/visitor";
 export const metadata = constructMetadata({
   title: "Agence web de développement et design UI/UX à Paris et Rouen",
   description: "Agence digitale spécialisée en développement web, mobile et design UI/UX. Notre équipe d'experts transforme vos idées en solutions digitales performantes.",
+  canonical: "https://onruntime.com/",
 });
 
 export default VisitorLanding;


### PR DESCRIPTION
This modification add a canonical link in home page to avoid potential unpredictable rankings if multiple versions of the same page are discovered at different URLs.